### PR TITLE
fixed compile error in gcc version 4.1.2

### DIFF
--- a/ngx_http_kafka_module.c
+++ b/ngx_http_kafka_module.c
@@ -159,7 +159,8 @@ void ngx_http_kafka_main_conf_broker_add(ngx_http_kafka_main_conf_t *cf,
     }
     cf->brokers[n].len = broker->len;
 
-    ngx_copy(cf->brokers[n].data, broker->data, broker->len);
+    //ngx_copy(cf->brokers[n].data, broker->data, broker->len);
+    memcpy(cf->brokers[n].data, broker->data, broker->len);
     cf->brokers[n].data[broker->len] = '\0';
     cf->nbrokers++;
 }
@@ -281,7 +282,7 @@ static void ngx_http_kafka_post_callback_handler(ngx_http_request_t *r)
     ngx_chain_t                  out;
     ngx_chain_t                 *cl, *in;
     ngx_http_request_body_t     *body;
-    ngx_http_kafka_main_conf_t  *main_conf;
+    ngx_http_kafka_main_conf_t  *main_conf = NULL;
     ngx_http_kafka_loc_conf_t   *local_conf;
 
     /* get body */


### PR DESCRIPTION
Hello.
I faced the problems while compiling this module with gcc version 4.1.2 and nginx-1.6.0.
And then i fixed codes. 

....
        -o objs/addon/ngx_kafka_module/ngx_http_kafka_module.o \
        /tmp/nginx/ngx_kafka_module/ngx_http_kafka_module.c
cc1: warnings being treated as errors
/tmp/nginx/ngx_kafka_module/ngx_http_kafka_module.c: In function ‘ngx_http_kafka_main_conf_broker_add’:
/tmp/nginx/ngx_kafka_module/ngx_http_kafka_module.c:162: warning: value computed is not used
make[1]: **\* [objs/addon/ngx_kafka_module/ngx_http_kafka_module.o] Error 1
make[1]: Leaving directory `/tmp/nginx/nginx-1.6.0'
make: **\* [build] Error 2

....
make -f objs/Makefile
make[1]: Entering directory `/tmp/nginx/nginx-1.6.0'
cc -c -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -I/usr/local/include/hiredis/  -I src/core -I src/event -I src/event/modules -I src/os/unix -I objs -I src/http -I src/http/modules -I src/http/modules/perl -I src/mail \
        -o objs/addon/ngx_kafka_module/ngx_http_kafka_module.o \
        /tmp/nginx/ngx_kafka_module/ngx_http_kafka_module.c
cc1: warnings being treated as errors
/tmp/nginx/ngx_kafka_module/ngx_http_kafka_module.c: In function ‘ngx_http_kafka_post_callback_handler’:
/tmp/nginx/ngx_kafka_module/ngx_http_kafka_module.c:285: warning: ‘main_conf’ may be used uninitialized in this function
make[1]: *** [objs/addon/ngx_kafka_module/ngx_http_kafka_module.o] Error 1
make[1]: Leaving directory`/tmp/nginx/nginx-1.6.0'
make: **\* [build] Error 2
